### PR TITLE
fix: show write token prompt on units.html save 403

### DIFF
--- a/web/units.html
+++ b/web/units.html
@@ -1112,6 +1112,13 @@ function saveUnitTag(u, newTag) {
     body: JSON.stringify({ alpha_tag: newTag, alpha_tag_source: 'manual' }),
   })
     .then(r => {
+      if (r.status === 401 || r.status === 403) {
+        saveStatus.textContent = 'Write token required';
+        saveStatus.className = 'unit-modal-save-status unit-modal-error';
+        saveBtn.disabled = false;
+        showAuth();
+        throw new Error('auth');
+      }
       if (!r.ok) throw new Error('HTTP ' + r.status);
       return r.json();
     })
@@ -1130,7 +1137,8 @@ function saveUnitTag(u, newTag) {
         u.el.setAttribute('data-tip', tip);
       }
     })
-    .catch(() => {
+    .catch((err) => {
+      if (err.message === 'auth') return;
       saveBtn.disabled = false;
       saveStatus.textContent = 'Error';
       saveStatus.className = 'unit-modal-save-status unit-modal-error';


### PR DESCRIPTION
## Summary
- `saveUnitTag()` in `units.html` now detects 401/403 on PATCH and shows the auth prompt with a "Write token required" status message
- Previously only showed a generic "Error" with no indication that a write token was needed
- Matches the 403 handling pattern already used by data-fetching code elsewhere on the same page

## Context
Users with only a read token (provided automatically via `auth.js` / `auth-init`) could browse units fine but got an unexplained "Error" when trying to save a unit name. The auth prompt never appeared because `auth.js` only intercepts 401s, and the server returns 403 (forbidden, not unauthorized) since the read token is valid but lacks write permissions.

## Test plan
- [ ] Open units.html without a write token configured
- [ ] Click a unit and try to edit its name
- [ ] Verify "Write token required" appears and the auth prompt opens
- [ ] Enter the write token and save again — verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)