### PR TITLE
Show TG ID in IRC titlebar for talkgroup-backed channels

### DIFF
--- a/web/irc-radio-live.html
+++ b/web/irc-radio-live.html
@@ -2660,7 +2660,7 @@ function saveChannelTag(newTag) {
       // Cancel edit UI and refresh display
       cancelChannelEdit();
       chanNameEl.textContent = finalName;
-      titlebarChan.textContent = finalName;
+      titlebarChan.textContent = state.tgid ? `${finalName} (TG ${state.tgid})` : finalName;
       renderTree();
     })
     .catch(err => {
@@ -2688,6 +2688,7 @@ function switchChannel(ch) {
 
   const state = channels.get(ch);
   const displayName = ch;
+  const titlebarDisplayName = state.tgid ? `${displayName} (TG ${state.tgid})` : displayName;
   const topic = state.description || state.tag || '';
 
   // Show/hide edit buttons based on whether channel has a tgid
@@ -2698,7 +2699,7 @@ function switchChannel(ch) {
   chanNameEl.textContent = displayName;
   chanTopicEl.textContent = topic;
   chanModeEl.textContent = state.mode ? `[${state.mode}]` : '';
-  titlebarChan.textContent = displayName;
+  titlebarChan.textContent = titlebarDisplayName;
   titlebarTopic.textContent = topic;
   inputPrompt.textContent = `[${displayName}]`;
 


### PR DESCRIPTION
Motivation

    Titlebar should show the numeric talkgroup context (e.g. (TG 1234)) when a channel is backed by a talkgroup so users can disambiguate channels with the same alpha tag.

Description

    Update switchChannel to set titlebarChan.textContent to include  (TG <tgid>) when state.tgid is present.
    Update the alpha-tag save flow so after renaming a talkgroup the titlebar continues to include  (TG <tgid>) by setting titlebarChan accordingly.

Testing

    Ran repository checks: git -C /workspace/tr-engine status --short and git -C /workspace/tr-engine show --stat --oneline HEAD, both succeeded.
