### PR TITLE
Add P25 Call Alert (TSBK 0x1F) ingest and display

### DIFF
--- a/internal/ingest/handler_units.go
+++ b/internal/ingest/handler_units.go
@@ -166,6 +166,26 @@ func (p *Pipeline) handleUnitEvent(eventType string, payload []byte) error {
 			}
 		}
 
+		// Call-alert events: upsert target unit and store target_unit in metadata_json
+		effectiveTargetUnitTag := data.TargetUnitAlphaTag
+		if eventType == "call_alert" && data.TargetUnit > 0 {
+			if dbTag, err := p.db.UpsertUnit(ctx, identity.SystemID, data.TargetUnit,
+				data.TargetUnitAlphaTag, "call_alert_target", ts, 0,
+			); err != nil {
+				p.log.Warn().Err(err).Int("target_unit", data.TargetUnit).Msg("failed to upsert target unit")
+			} else if dbTag != "" {
+				effectiveTargetUnitTag = dbTag
+			}
+
+			meta := map[string]any{
+				"target_unit":           data.TargetUnit,
+				"target_unit_alpha_tag": effectiveTargetUnitTag,
+			}
+			if b, err := json.Marshal(meta); err == nil {
+				row.MetadataJSON = b
+			}
+		}
+
 		if err := p.db.InsertUnitEvent(ctx, row); err != nil {
 			return fmt.Errorf("insert unit event: %w", err)
 		}
@@ -183,6 +203,10 @@ func (p *Pipeline) handleUnitEvent(eventType string, payload []byte) error {
 		if eventType == "signal" {
 			ssePayload["signaling_type"] = data.SignalingType
 			ssePayload["signal_type"] = data.SignalType
+		}
+		if eventType == "call_alert" {
+			ssePayload["target_unit"] = data.TargetUnit
+			ssePayload["target_unit_alpha_tag"] = effectiveTargetUnitTag
 		}
 
 		p.PublishEvent(EventData{

--- a/internal/ingest/handler_units_test.go
+++ b/internal/ingest/handler_units_test.go
@@ -113,45 +113,169 @@ func TestParseUnitEventData(t *testing.T) {
 			t.Error("expected error for invalid JSON")
 		}
 	})
+
+	t.Run("call_alert_event", func(t *testing.T) {
+		// Payload format produced by the mqtt_status plugin's send_json():
+		// {"type":"call_alert","call_alert":{...},"timestamp":...,"instance_id":"..."}
+		payload := []byte(`{
+			"type": "call_alert",
+			"call_alert": {
+				"sys_num": 1,
+				"sys_name": "pscsite4",
+				"unit": 4810011,
+				"unit_alpha_tag": "",
+				"target_unit": 4811289,
+				"target_unit_alpha_tag": "OFFICER JONES"
+			},
+			"timestamp": 1712789072,
+			"instance_id": "trunk-recorder"
+		}`)
+		env, data, err := parseUnitEventData(payload, "call_alert")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if env.InstanceID != "trunk-recorder" {
+			t.Errorf("InstanceID = %q, want %q", env.InstanceID, "trunk-recorder")
+		}
+		if env.Timestamp != 1712789072 {
+			t.Errorf("Timestamp = %d, want 1712789072", env.Timestamp)
+		}
+		if data.Unit != 4810011 {
+			t.Errorf("Unit = %d, want 4810011", data.Unit)
+		}
+		if data.SysName != "pscsite4" {
+			t.Errorf("SysName = %q, want %q", data.SysName, "pscsite4")
+		}
+		if data.TargetUnit != 4811289 {
+			t.Errorf("TargetUnit = %d, want 4811289", data.TargetUnit)
+		}
+		if data.TargetUnitAlphaTag != "OFFICER JONES" {
+			t.Errorf("TargetUnitAlphaTag = %q, want %q", data.TargetUnitAlphaTag, "OFFICER JONES")
+		}
+		// call_alert has no talkgroup
+		if data.Talkgroup != 0 {
+			t.Errorf("Talkgroup = %d, want 0 (no talkgroup on call_alert)", data.Talkgroup)
+		}
+	})
+
+	t.Run("call_alert_no_alpha_tags", func(t *testing.T) {
+		// Typical real-world payload where unit tags are not configured
+		payload := []byte(`{
+			"type": "call_alert",
+			"call_alert": {
+				"sys_num": 1,
+				"sys_name": "pscsite4",
+				"unit": 4810011,
+				"unit_alpha_tag": "",
+				"target_unit": 4811292,
+				"target_unit_alpha_tag": ""
+			},
+			"timestamp": 1712789100,
+			"instance_id": "trunk-recorder"
+		}`)
+		_, data, err := parseUnitEventData(payload, "call_alert")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if data.TargetUnit != 4811292 {
+			t.Errorf("TargetUnit = %d, want 4811292", data.TargetUnit)
+		}
+		if data.TargetUnitAlphaTag != "" {
+			t.Errorf("TargetUnitAlphaTag = %q, want empty", data.TargetUnitAlphaTag)
+		}
+	})
 }
 
 // ── round-trip: route parsing + payload parsing ─────────────────────
 
 func TestUnitEventParseRoundTrip(t *testing.T) {
-	topic := "trengine/units/butco/join"
-	payload, _ := json.Marshal(map[string]any{
-		"type":        "unit_event",
-		"timestamp":   1700000000,
-		"instance_id": "tr-1",
-		"join": map[string]any{
-			"sys_name":  "butco",
-			"unit":      12345,
-			"talkgroup": 100,
-		},
+	t.Run("join", func(t *testing.T) {
+		topic := "trengine/units/butco/join"
+		payload, _ := json.Marshal(map[string]any{
+			"type":        "unit_event",
+			"timestamp":   1700000000,
+			"instance_id": "tr-1",
+			"join": map[string]any{
+				"sys_name":  "butco",
+				"unit":      12345,
+				"talkgroup": 100,
+			},
+		})
+
+		route := ParseTopic(topic)
+		if route == nil {
+			t.Fatal("ParseTopic returned nil")
+		}
+		if route.Handler != "unit_event" {
+			t.Fatalf("Handler = %q, want %q", route.Handler, "unit_event")
+		}
+		if route.EventType != "join" {
+			t.Fatalf("EventType = %q, want %q", route.EventType, "join")
+		}
+
+		env, data, err := parseUnitEventData(payload, route.EventType)
+		if err != nil {
+			t.Fatalf("parseUnitEventData: %v", err)
+		}
+		if env.InstanceID != "tr-1" {
+			t.Errorf("InstanceID = %q, want %q", env.InstanceID, "tr-1")
+		}
+		if data.Unit != 12345 {
+			t.Errorf("Unit = %d, want 12345", data.Unit)
+		}
+		if data.Talkgroup != 100 {
+			t.Errorf("Talkgroup = %d, want 100", data.Talkgroup)
+		}
 	})
 
-	route := ParseTopic(topic)
-	if route == nil {
-		t.Fatal("ParseTopic returned nil")
-	}
-	if route.Handler != "unit_event" {
-		t.Fatalf("Handler = %q, want %q", route.Handler, "unit_event")
-	}
-	if route.EventType != "join" {
-		t.Fatalf("EventType = %q, want %q", route.EventType, "join")
-	}
+	t.Run("call_alert", func(t *testing.T) {
+		topic := "tr/units/pscsite4/call_alert"
+		payload, _ := json.Marshal(map[string]any{
+			"type":        "call_alert",
+			"timestamp":   1712789072,
+			"instance_id": "trunk-recorder",
+			"call_alert": map[string]any{
+				"sys_num":              1,
+				"sys_name":             "pscsite4",
+				"unit":                 4810011,
+				"unit_alpha_tag":       "",
+				"target_unit":          4811289,
+				"target_unit_alpha_tag": "OFFICER JONES",
+			},
+		})
 
-	env, data, err := parseUnitEventData(payload, route.EventType)
-	if err != nil {
-		t.Fatalf("parseUnitEventData: %v", err)
-	}
-	if env.InstanceID != "tr-1" {
-		t.Errorf("InstanceID = %q, want %q", env.InstanceID, "tr-1")
-	}
-	if data.Unit != 12345 {
-		t.Errorf("Unit = %d, want 12345", data.Unit)
-	}
-	if data.Talkgroup != 100 {
-		t.Errorf("Talkgroup = %d, want 100", data.Talkgroup)
-	}
+		route := ParseTopic(topic)
+		if route == nil {
+			t.Fatal("ParseTopic returned nil for call_alert topic")
+		}
+		if route.Handler != "unit_event" {
+			t.Fatalf("Handler = %q, want unit_event", route.Handler)
+		}
+		if route.EventType != "call_alert" {
+			t.Fatalf("EventType = %q, want call_alert", route.EventType)
+		}
+		if route.SysName != "pscsite4" {
+			t.Fatalf("SysName = %q, want pscsite4", route.SysName)
+		}
+
+		env, data, err := parseUnitEventData(payload, route.EventType)
+		if err != nil {
+			t.Fatalf("parseUnitEventData: %v", err)
+		}
+		if env.InstanceID != "trunk-recorder" {
+			t.Errorf("InstanceID = %q, want trunk-recorder", env.InstanceID)
+		}
+		if data.Unit != 4810011 {
+			t.Errorf("Unit = %d, want 4810011", data.Unit)
+		}
+		if data.TargetUnit != 4811289 {
+			t.Errorf("TargetUnit = %d, want 4811289", data.TargetUnit)
+		}
+		if data.TargetUnitAlphaTag != "OFFICER JONES" {
+			t.Errorf("TargetUnitAlphaTag = %q, want OFFICER JONES", data.TargetUnitAlphaTag)
+		}
+		if data.Talkgroup != 0 {
+			t.Errorf("Talkgroup = %d, want 0", data.Talkgroup)
+		}
+	})
 }

--- a/internal/ingest/messages.go
+++ b/internal/ingest/messages.go
@@ -170,6 +170,9 @@ type UnitEventData struct {
 	// Signal-specific fields (from signal events)
 	SignalingType string `json:"signaling_type,omitempty"`
 	SignalType    string `json:"signal_type,omitempty"`
+	// Call-alert-specific fields (from call_alert events)
+	TargetUnit         int    `json:"target_unit,omitempty"`
+	TargetUnitAlphaTag string `json:"target_unit_alpha_tag,omitempty"`
 }
 
 // UnitEventMsg wraps a unit event message. The event data is keyed by the event type.

--- a/internal/ingest/router.go
+++ b/internal/ingest/router.go
@@ -4,9 +4,9 @@ import "strings"
 
 // Route describes a parsed MQTT topic.
 type Route struct {
-	Handler   string // handler name: "status", "console", "systems", "system", "calls_active", "call_start", "call_end", "audio", "recorders", "recorder", "rates", "trunking_message", "unit_event" (includes signal)
+	Handler   string // handler name: "status", "console", "systems", "system", "calls_active", "call_start", "call_end", "audio", "recorders", "recorder", "rates", "trunking_message", "unit_event" (includes signal, call_alert)
 	SysName   string // set for unit event and trunking message topics
-	EventType string // set for unit events: "on", "off", "call", "end", "join", etc.
+	EventType string // set for unit events: "on", "off", "call", "end", "join", "call_alert", etc.
 }
 
 // ParseTopic maps an MQTT topic string to a Route.
@@ -36,7 +36,7 @@ type Route struct {
 //
 // Unit event topics ({unit_topic}/...):
 //
-//	.../{sys_name}/{event_type} → unit_event
+//	.../{sys_name}/{event_type} → unit_event  (on, off, call, end, join, location, ackresp, data, signal, call_alert)
 func ParseTopic(topic string) *Route {
 	parts := strings.Split(topic, "/")
 	n := len(parts)
@@ -75,7 +75,7 @@ func ParseTopic(topic string) *Route {
 
 	// Unit events: .../{sys_name}/{event_type}
 	switch last {
-	case "on", "off", "call", "end", "join", "location", "ackresp", "data", "signal":
+	case "on", "off", "call", "end", "join", "location", "ackresp", "data", "signal", "call_alert":
 		if n >= 2 {
 			return &Route{Handler: "unit_event", SysName: parts[n-2], EventType: last}
 		}

--- a/internal/ingest/router_test.go
+++ b/internal/ingest/router_test.go
@@ -36,6 +36,7 @@ func TestParseTopic(t *testing.T) {
 		{name: "unit_join", topic: "trengine/units/butco/join", want: &Route{Handler: "unit_event", SysName: "butco"}},
 		{name: "unit_ackresp", topic: "trengine/units/butco/ackresp", want: &Route{Handler: "unit_event", SysName: "butco"}},
 		{name: "unit_data", topic: "trengine/units/butco/data", want: &Route{Handler: "unit_event", SysName: "butco"}},
+		{name: "unit_call_alert", topic: "tr/units/pscsite4/call_alert", want: &Route{Handler: "unit_event", SysName: "pscsite4", EventType: "call_alert"}},
 
 		// Custom prefixes — router only cares about trailing segments
 		{name: "custom_prefix_feed", topic: "myradio/whatever/call_start", want: &Route{Handler: "call_start"}},

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3700,7 +3700,7 @@ components:
 
     EventType:
       type: string
-      enum: [on, off, join, call, end, data, ans_req, location, ackresp, signal]
+      enum: [on, off, join, call, end, data, ans_req, location, ackresp, signal, call_alert]
       description: |
         Unit event types from trunk-recorder MQTT:
         - **on**: unit registration (radio powered on / entering system)
@@ -3713,6 +3713,7 @@ components:
         - **location**: unit location update
         - **ackresp**: acknowledge response
         - **signal**: in-band signaling decode (MDC1200, FleetSync, STAR)
+        - **call_alert**: directed unit-to-unit page (P25 TSBK 0x1F); `target_unit` and `target_unit_alpha_tag` present in SSE payload and `metadata_json`
 
     CallState:
       type: string
@@ -4434,6 +4435,20 @@ components:
             `radio_check`, `radio_stun`, `radio_revive`, and their `_ack`/`_pre` variants.
             Only present in SSE payloads for `unit_event:signal` events.
           example: normal
+
+        # Call-alert-specific fields (present only for event_type=call_alert, via SSE)
+        target_unit:
+          type: integer
+          description: |
+            Unit ID of the radio being paged (P25 Call Alert, TSBK 0x1F).
+            Only present in SSE payloads for `unit_event:call_alert` events.
+          example: 4811289
+        target_unit_alpha_tag:
+          type: string
+          description: |
+            Alpha tag for the paged unit, if known.
+            Only present in SSE payloads for `unit_event:call_alert` events.
+          example: "OFFICER JONES"
 
     CallFrequency:
       type: object

--- a/web/events.html
+++ b/web/events.html
@@ -104,6 +104,7 @@
   .type-call_start  { background: color-mix(in srgb, var(--info) 20%, transparent); color: var(--info); }
   .type-call_end    { background: color-mix(in srgb, var(--success) 20%, transparent); color: var(--success); }
   .type-call_update { background: color-mix(in srgb, var(--cyan) 15%, transparent); color: var(--cyan); }
+  .type-call_alert  { background: color-mix(in srgb, #cc2200 25%, transparent); color: #ff4422; font-weight: 700; }
   .type-unit_event  { background: color-mix(in srgb, var(--magenta) 20%, transparent); color: var(--magenta); }
   .type-recorder_update { background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning); }
   .type-rate_update { background: var(--bg-tile); color: var(--text-muted); }
@@ -146,6 +147,7 @@
   <div class="filters">
     <label><input type="checkbox" value="call_start" checked> call_start</label>
     <label><input type="checkbox" value="call_end" checked> call_end</label>
+    <label><input type="checkbox" value="call_alert" checked> call_alert</label>
     <label><input type="checkbox" value="unit_event" checked> unit_event</label>
     <label><input type="checkbox" value="recorder_update" checked> recorder_update</label>
     <label><input type="checkbox" value="rate_update"> rate_update</label>
@@ -173,7 +175,13 @@ let everConnected = false;
 const EVENT_TYPES = ['call_start', 'call_end', 'call_update', 'unit_event', 'recorder_update', 'rate_update', 'trunking_message', 'console'];
 
 function getSelectedTypes() {
-  return Array.from(document.querySelectorAll('.filters input:checked')).map(cb => cb.value);
+  const checked = new Set(Array.from(document.querySelectorAll('.filters input:checked')).map(cb => cb.value));
+  // call_alert is a unit_event subtype — always subscribe to unit_event so we receive them,
+  // then filter client-side in addEvent based on the call_alert checkbox.
+  const ssTypes = new Set(checked);
+  if (checked.has('call_alert')) ssTypes.add('unit_event');
+  ssTypes.delete('call_alert');
+  return [...ssTypes];
 }
 
 function setStatus(state, text) {
@@ -204,6 +212,10 @@ function formatDetail(type, d) {
         ` <span class="dim">dur=</span>${d.duration ? d.duration.toFixed(1) + 's' : '?'}` +
         ` <span class="dim">freq=</span>${(d.freq / 1e6).toFixed(4)}` +
         (d.emergency ? ' <span class="emergency">EMERGENCY</span>' : '');
+    case 'call_alert':
+      return `<span class="val">${esc(d.unit_alpha_tag || 'Unit ' + d.unit_id)}</span>` +
+        ` <span class="dim">→</span>` +
+        ` <span class="val">${esc(d.target_unit_alpha_tag || 'Unit ' + d.target_unit)}</span>`;
     case 'unit_event':
       return `<span class="dim">${esc(d.event_type || '?')}</span>` +
         ` <span class="val">${esc(d.unit_alpha_tag || 'Unit ' + d.unit_id)}</span>` +
@@ -235,6 +247,17 @@ function esc(s) {
 }
 
 function addEvent(type, data) {
+  // Remap call_alert from unit_event subtype to its own display type
+  let displayType = type;
+  if (type === 'unit_event' && data.event_type === 'call_alert') {
+    displayType = 'call_alert';
+  }
+
+  // Client-side filter: check if displayType is enabled
+  const checked = new Set(Array.from(document.querySelectorAll('.filters input:checked')).map(cb => cb.value));
+  if (displayType === 'call_alert' && !checked.has('call_alert')) return;
+  if (displayType === 'unit_event' && !checked.has('unit_event')) return;
+
   totalCount++;
   eventCountEl.textContent = totalCount;
 
@@ -246,8 +269,8 @@ function addEvent(type, data) {
 
   row.innerHTML =
     `<span class="event-time">${time}</span>` +
-    `<span class="event-type type-${type}">${type.replace('_', ' ')}</span>` +
-    `<span class="event-detail">${formatDetail(type, data)}</span>`;
+    `<span class="event-type type-${displayType}">${displayType.replace(/_/g, ' ')}</span>` +
+    `<span class="event-detail">${formatDetail(displayType, data)}</span>`;
 
   eventsEl.insertBefore(row, eventsEl.firstChild);
 

--- a/web/index.html
+++ b/web/index.html
@@ -599,6 +599,7 @@ const EVENT_TYPES = {
   unit_ackresp:  { label:'unit ack',    color:'linear-gradient(135deg, #fbbf24, #f59e0b)' },
   unit_data:     { label:'unit data',   color:'linear-gradient(135deg, #2dd4bf, #14b8a6)' },
   unit_signal:   { label:'unit sig',   color:'linear-gradient(135deg, #f59e0b, #d97706)' },
+  unit_call_alert: { label:'call alert', color:'linear-gradient(135deg, #cc2200, #ff4422)' },
 };
 const eventBuckets = {};
 for (const t of Object.keys(EVENT_TYPES)) eventBuckets[t] = [];
@@ -643,7 +644,7 @@ renderRateBars();
 /* ═══ Streak Engine ═══ */
 const streakCanvas = document.getElementById('streak-canvas'), sCtx = streakCanvas.getContext('2d');
 let streaks = [], streakRAF = null, lastStreakTime = 0;
-const STREAK_COLORS = { call:{r:217,g:70,b:239}, end:{r:232,g:121,b:249}, on:{r:167,g:139,b:250}, off:{r:196,g:181,b:253}, join:{r:244,g:114,b:182}, location:{r:251,g:146,b:60}, ackresp:{r:251,g:191,b:36}, data:{r:45,g:212,b:191}, signal:{r:245,g:158,b:11}, default:{r:96,g:165,b:250} };
+const STREAK_COLORS = { call:{r:217,g:70,b:239}, end:{r:232,g:121,b:249}, on:{r:167,g:139,b:250}, off:{r:196,g:181,b:253}, join:{r:244,g:114,b:182}, location:{r:251,g:146,b:60}, ackresp:{r:251,g:191,b:36}, data:{r:45,g:212,b:191}, signal:{r:245,g:158,b:11}, call_alert:{r:204,g:34,b:0}, default:{r:96,g:165,b:250} };
 
 function resizeStreakCanvas() { streakCanvas.width = window.innerWidth; streakCanvas.height = window.innerHeight; }
 resizeStreakCanvas(); window.addEventListener('resize', resizeStreakCanvas);

--- a/web/irc-radio-live.html
+++ b/web/irc-radio-live.html
@@ -750,6 +750,7 @@ body::after {
 .unit-event-type.state-data { background: color-mix(in srgb, var(--irc-warning) 65%, var(--bg-surface)); color: #000; }
 .unit-event-type.state-signal { background: var(--irc-warning); color: #000; }
 .unit-event-type.state-off { background: var(--text-faint); color: var(--bg-surface); }
+.unit-event-type.state-call-alert { background: #cc2200; color: #fff; font-weight: 700; }
 .unit-event-tg {
   color: var(--text-muted); white-space: nowrap; overflow: hidden;
   text-overflow: ellipsis; flex: 1; min-width: 0;
@@ -1604,6 +1605,7 @@ function eventTypeStateClass(eventType) {
     case 'location': return 'state-location';
     case 'ackresp': case 'data': return 'state-data';
     case 'signal': return 'state-signal';
+    case 'call_alert': return 'state-call-alert';
     default: return 'state-affiliated';
   }
 }
@@ -4062,6 +4064,15 @@ function handleUnitEvent(evt) {
           text: `${nick} sent ${sigType} signal`,
         });
       }
+      break;
+    }
+
+    case 'call_alert': {
+      // Directed unit-to-unit page (P25 TSBK 0x1F) — no talkgroup, post to *status
+      const targetId = evt.target_unit;
+      const targetTag = evt.target_unit_alpha_tag;
+      const targetNick = targetId ? resolveNick(systemId, targetId, targetTag) : '?';
+      serverMsg(`\u{1F6A8} CALL ALERT: ${nick} \u2192 ${targetNick}`);
       break;
     }
 

--- a/web/omnitrunker-classic.html
+++ b/web/omnitrunker-classic.html
@@ -245,6 +245,7 @@
   .badge-location { background: color-mix(in srgb, var(--cyan) 20%, transparent); color: var(--cyan); }
   .badge-call-end { background: var(--bg-tile); color: var(--text-faint); }
   .badge-signal { background: color-mix(in srgb, var(--magenta) 15%, transparent); color: var(--magenta); }
+  .badge-call-alert { background: color-mix(in srgb, #cc2200 25%, transparent); color: #ff4422; font-weight: 700; }
 
   .encrypted-badge {
     display: inline-block;
@@ -373,6 +374,7 @@
         <option value="location">Location</option>
         <option value="call-end">Call End</option>
         <option value="signal">Signal</option>
+        <option value="call-alert">Call Alert</option>
       </select></label>
       <label><input type="checkbox" id="auto-scroll" checked> Auto-scroll</label>
       <button id="clear-btn">Clear</button>
@@ -512,6 +514,8 @@ function getBadgeInfo(eventType) {
       return { cls: 'badge-call-end', label: 'CALL END' };
     case 'signal':
       return { cls: 'badge-signal', label: 'SIGNAL' };
+    case 'call_alert':
+      return { cls: 'badge-call-alert', label: 'CALL ALERT' };
     default:
       return { cls: 'badge-data', label: String(eventType || '?').toUpperCase() };
   }
@@ -529,6 +533,7 @@ function getFilterKey(eventType) {
     case 'location': return 'location';
     case 'end': case 'call_end': case 'call-end': return 'call-end';
     case 'signal': return 'signal';
+    case 'call_alert': return 'call-alert';
     default: return eventType;
   }
 }
@@ -763,14 +768,18 @@ function buildActivityRow(eventType, data) {
   c5.appendChild(badgeSpan);
   row.appendChild(c5);
 
-  // TG
+  // TG (for call_alert: show target unit instead)
   const c6 = document.createElement('td');
-  c6.textContent = tgid != null ? String(tgid) : '';
+  c6.textContent = eventType === 'call_alert'
+    ? (data.target_unit != null ? '→ ' + String(data.target_unit) : '')
+    : (tgid != null ? String(tgid) : '');
   row.appendChild(c6);
 
-  // TG Alpha
+  // TG Alpha (for call_alert: show target unit alpha tag)
   const c7 = document.createElement('td');
-  c7.textContent = tgAlpha;
+  c7.textContent = eventType === 'call_alert'
+    ? (data.target_unit_alpha_tag || '')
+    : tgAlpha;
   row.appendChild(c7);
 
   return row;

--- a/web/omnitrunker.html
+++ b/web/omnitrunker.html
@@ -259,6 +259,7 @@
   .badge-location { background: color-mix(in srgb, var(--cyan) 20%, transparent); color: var(--cyan); }
   .badge-call-end { background: var(--bg-tile); color: var(--text-faint); }
   .badge-signal { background: color-mix(in srgb, var(--magenta) 15%, transparent); color: var(--magenta); }
+  .badge-call-alert { background: color-mix(in srgb, #cc2200 25%, transparent); color: #ff4422; font-weight: 700; }
 
   .encrypted-badge {
     display: inline-block;
@@ -1150,6 +1151,7 @@ const typeFilterDropdown = new MultiSelectDropdown(
       ['location', 'Location'],
       ['call-end', 'Call End'],
       ['signal', 'Signal'],
+      ['call-alert', 'Call Alert'],
     ],
     onChange: onTypeFilterChange,
   }
@@ -1251,6 +1253,8 @@ function getBadgeInfo(eventType) {
       return { cls: 'badge-call-end', label: 'CALL END' };
     case 'signal':
       return { cls: 'badge-signal', label: 'SIGNAL' };
+    case 'call_alert':
+      return { cls: 'badge-call-alert', label: 'CALL ALERT' };
     default:
       return { cls: 'badge-data', label: String(eventType || '?').toUpperCase() };
   }
@@ -1268,6 +1272,7 @@ function getFilterKey(eventType) {
     case 'location': return 'location';
     case 'end': case 'call_end': case 'call-end': return 'call-end';
     case 'signal': return 'signal';
+    case 'call_alert': return 'call-alert';
     default: return eventType;
   }
 }
@@ -1751,14 +1756,18 @@ function buildActivityRow(eventType, data) {
   c5.appendChild(badgeSpan);
   row.appendChild(c5);
 
-  // TG
+  // TG (for call_alert: show target unit instead)
   const c6 = document.createElement('td');
-  c6.textContent = tgid != null ? String(tgid) : '';
+  c6.textContent = eventType === 'call_alert'
+    ? (data.target_unit != null ? '→ ' + String(data.target_unit) : '')
+    : (tgid != null ? String(tgid) : '');
   row.appendChild(c6);
 
-  // TG Alpha
+  // TG Alpha (for call_alert: show target unit alpha tag)
   const c7 = document.createElement('td');
-  c7.textContent = tgAlpha;
+  c7.textContent = eventType === 'call_alert'
+    ? (data.target_unit_alpha_tag || '')
+    : tgAlpha;
   row.appendChild(c7);
 
   return row;


### PR DESCRIPTION
## ⚠️ HARD DEPENDENCY — DO NOT MERGE UNTIL BOTH UPSTREAM PRs ARE MERGED ⚠️

This PR **will not function** without the following two PRs being merged first. There is no trunk-recorder code to emit call_alert MQTT messages until they land:

| # | Repo | What it does | Status needed |
|---|------|-------------|---------------|
| TrunkRecorder/trunk-recorder#1126 | trunk-recorder | Decodes TSBK opcode 0x1F into a `CALL_ALERT` message type and dispatches it through the plugin API | **Must merge first** |
| TrunkRecorder/tr-plugin-mqtt#8 | tr-plugin-mqtt | Implements `unit_call_alert()` in mqtt_status plugin — publishes payload to `tr/units/{sys_name}/call_alert` | **Must merge second** |

If either is missing, trunk-recorder silently drops all Call Alert TSBK messages and tr-engine receives nothing on this topic.

---

## What is a P25 Call Alert?

A Call Alert (TSBK opcode 0x1F) is a directed unit-to-unit page — one radio paging another with no voice channel. Common use: CAD dispatcher silently paging an individual officer. No audio. The MQTT message carries source unit and target unit IDs only.

MQTT topic: `tr/units/{sys_name}/call_alert`

## Changes

### Ingest (`internal/ingest/`)
- **router.go** — routes `tr/units/{sys}/call_alert` to the `unit_event` handler as subtype `call_alert`
- **messages.go** — adds `TargetUnit` / `TargetUnitAlphaTag` fields to `UnitEventData`
- **handler_units.go** — upserts source and target units, stores `target_unit` in `metadata_json`, publishes SSE as `unit_event:call_alert` with `target_unit` and `target_unit_alpha_tag`
- **router_test.go**, **handler_units_test.go** — full test coverage

### API (`openapi.yaml`)
- Adds `call_alert` to the `EventType` enum
- Documents `target_unit` / `target_unit_alpha_tag` SSE payload fields

### Web UI
- **events.html** (Live Events) — red bold CALL ALERT badge, `Unit A → Unit B` detail, dedicated filter checkbox
- **index.html** (Event Horizon) — call alert row in rate meter (red gradient), red background streak
- **omnitrunker.html** — red CALL ALERT badge, target unit in TG columns, filterable
- **omnitrunker-classic.html** — same as omnitrunker
- **irc-radio-live.html** — 🚨 CALL ALERT: UnitA → UnitB posted to *status (no talkgroup, so goes to system status channel)

## Test plan
- [ ] Merge TrunkRecorder/trunk-recorder#1126
- [ ] Merge TrunkRecorder/tr-plugin-mqtt#8
- [ ] Confirm `tr/units/{sys}/call_alert` messages arrive at MQTT broker
- [ ] Confirm rows appear in `unit_events` with `metadata_json.target_unit`
- [ ] Red CALL ALERT badge visible in Live Events
- [ ] Event Horizon rate meter shows call alert bar
- [ ] Omnitrunker shows badge with target unit in TG column
- [ ] IRC *status receives alert message

🤖 Generated with [Claude Code](https://claude.com/claude-code)