### PR TITLE
fix: preserve manual talkgroup edits

### DIFF
--- a/internal/database/talkgroups.go
+++ b/internal/database/talkgroups.go
@@ -12,13 +12,13 @@ import (
 
 // TalkgroupFilter specifies filters for listing talkgroups.
 type TalkgroupFilter struct {
-	SystemIDs  []int
-	Sysids     []string
-	Group      *string
-	Search     *string
-	Limit      int
-	Offset     int
-	Sort       string
+	SystemIDs []int
+	Sysids    []string
+	Group     *string
+	Search    *string
+	Limit     int
+	Offset    int
+	Sort      string
 }
 
 // TalkgroupAPI represents a talkgroup for API responses.
@@ -160,6 +160,7 @@ func (db *DB) UpdateTalkgroupFields(ctx context.Context, systemID, tgid int,
 	if alphaTagSource != nil {
 		atsVal = *alphaTagSource
 	}
+	atsVal = effectiveTalkgroupPatchSource(atsVal, alphaTag, description, group, tag, priority)
 	descVal := ""
 	if description != nil {
 		descVal = *description
@@ -187,6 +188,13 @@ func (db *DB) UpdateTalkgroupFields(ctx context.Context, systemID, tgid int,
 		SystemID:       systemID,
 		Tgid:           tgid,
 	})
+}
+
+func effectiveTalkgroupPatchSource(current string, alphaTag, description, group, tag *string, priority *int) string {
+	if alphaTag != nil || description != nil || group != nil || tag != nil || priority != nil {
+		return "manual"
+	}
+	return current
 }
 
 // UpsertTalkgroup inserts or updates a talkgroup, never overwriting good data with empty strings.

--- a/internal/database/talkgroups_test.go
+++ b/internal/database/talkgroups_test.go
@@ -1,0 +1,32 @@
+package database
+
+import "testing"
+
+func TestEffectiveTalkgroupPatchSource(t *testing.T) {
+	text := "value"
+	priority := 1
+
+	tests := []struct {
+		name    string
+		current string
+		got     string
+		want    string
+	}{
+		{"no mutable fields preserves empty source", "", effectiveTalkgroupPatchSource("", nil, nil, nil, nil, nil), ""},
+		{"no mutable fields preserves explicit source", "csv", effectiveTalkgroupPatchSource("csv", nil, nil, nil, nil, nil), "csv"},
+		{"alpha tag marks manual", "", effectiveTalkgroupPatchSource("", &text, nil, nil, nil, nil), "manual"},
+		{"description marks manual", "", effectiveTalkgroupPatchSource("", nil, &text, nil, nil, nil), "manual"},
+		{"group marks manual", "", effectiveTalkgroupPatchSource("", nil, nil, &text, nil, nil), "manual"},
+		{"tag marks manual", "", effectiveTalkgroupPatchSource("", nil, nil, nil, &text, nil), "manual"},
+		{"priority marks manual", "", effectiveTalkgroupPatchSource("", nil, nil, nil, nil, &priority), "manual"},
+		{"mutable field overrides explicit source", "csv", effectiveTalkgroupPatchSource("csv", &text, nil, nil, nil, nil), "manual"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("effectiveTalkgroupPatchSource(%q) = %q, want %q", tt.current, tt.got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- mark API talkgroup PATCH updates as manual edits in the database wrapper
- add coverage for source selection so mutable field patches override MQTT/csv source passthrough

Fixes #37

## Testing
- GOCACHE=/tmp/tr-engine-go-cache go test ./internal/database
- GOCACHE=/tmp/tr-engine-go-cache go vet ./...
- GOCACHE=/tmp/tr-engine-go-cache GOFLAGS=-buildvcs=false bash build.sh

Note: build uses GOFLAGS=-buildvcs=false because this temporary worktree cannot provide Go VCS stamping metadata.