### PR TITLE
fix: skip non-dvcf IMBE backfill calls

### DIFF
--- a/internal/ingest/backfill.go
+++ b/internal/ingest/backfill.go
@@ -2,6 +2,8 @@ package ingest
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -307,6 +309,14 @@ func (bm *BackfillManager) enqueueCall(ctx context.Context, callID int64) bool {
 		bm.log.Warn().Err(err).Int64("call_id", callID).Msg("backfill: failed to load call")
 		return false
 	}
+	if backfillShouldSkipForProvider(bm.transcriber.ProviderName(), c.AudioFilePath) {
+		bm.log.Debug().
+			Int64("call_id", callID).
+			Str("provider", bm.transcriber.ProviderName()).
+			Str("audio_file_path", c.AudioFilePath).
+			Msg("backfill: skipping call without dvcf file for IMBE provider")
+		return false
+	}
 	return bm.transcriber.Enqueue(transcribe.Job{
 		CallID:        c.CallID,
 		CallStartTime: c.StartTime,
@@ -321,6 +331,10 @@ func (bm *BackfillManager) enqueueCall(ctx context.Context, callID int64) bool {
 		TgTag:         c.TgTag,
 		TgGroup:       c.TgGroup,
 	})
+}
+
+func backfillShouldSkipForProvider(providerName, audioFilePath string) bool {
+	return strings.EqualFold(providerName, "imbe") && !strings.EqualFold(filepath.Ext(audioFilePath), ".dvcf")
 }
 
 func (bm *BackfillManager) toDBFilter(f BackfillFilters) database.BackfillFilter {

--- a/internal/ingest/backfill_test.go
+++ b/internal/ingest/backfill_test.go
@@ -1,0 +1,28 @@
+package ingest
+
+import "testing"
+
+func TestBackfillShouldSkipForProvider(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		audioPath string
+		want      bool
+	}{
+		{"whisper accepts m4a", "whisper", "calls/2026/05/call.m4a", false},
+		{"whisper accepts empty path", "whisper", "", false},
+		{"imbe accepts dvcf", "imbe", "calls/2026/05/call.dvcf", false},
+		{"imbe accepts uppercase dvcf", "imbe", "calls/2026/05/call.DVCF", false},
+		{"imbe skips m4a", "imbe", "calls/2026/05/call.m4a", true},
+		{"imbe skips empty path", "imbe", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := backfillShouldSkipForProvider(tt.provider, tt.audioPath)
+			if got != tt.want {
+				t.Fatalf("backfillShouldSkipForProvider(%q, %q) = %v, want %v", tt.provider, tt.audioPath, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- skip transcription backfill entries without a .dvcf path when the active provider is IMBE
- avoid feeding historical audio-only calls to the IMBE worker
- add coverage for provider/path skip behavior

Fixes #8

## Testing
- GOCACHE=/tmp/tr-engine-go-cache go test ./internal/ingest
- GOCACHE=/tmp/tr-engine-go-cache go vet ./...
- GOCACHE=/tmp/tr-engine-go-cache GOFLAGS=-buildvcs=false bash build.sh

Note: build uses GOFLAGS=-buildvcs=false because this temporary worktree cannot provide Go VCS stamping metadata.