### PR TITLE
docs: document GET /auth/setup in OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -209,6 +209,37 @@ paths:
                     description: Whether JWT login endpoints are available
 
   /auth/setup:
+    get:
+      operationId: checkAuthSetup
+      summary: Check whether first-run setup is needed
+      description: |
+        Returns whether the instance has completed first-run admin setup.
+        Unauthenticated — always available when JWT auth is configured.
+        The dashboard calls this endpoint to decide whether to show the
+        admin setup flow or the regular login page.
+      tags: [auth]
+      security: []
+      responses:
+        "200":
+          description: Setup status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  needs_setup:
+                    type: boolean
+                    description: true when zero users exist (first-run setup pending)
+                  user_count:
+                    type: integer
+                    description: Total number of users in the database
+        "500":
+          description: Database error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
     post:
       operationId: authSetup
       summary: First-run admin creation


### PR DESCRIPTION
## Summary

- Adds `GET /auth/setup` operation to `openapi.yaml` as `checkAuthSetup`
- Response schema matches `SetupHandler.Status()` exactly: `{needs_setup: boolean, user_count: integer}`
- `security: []` (unauthenticated), `tags: [auth]`, 200 + 500 responses
- Enables dashboard type generation for the first-run setup check (`checkNeedsSetup()`)

## Test plan

- [ ] Confirm `GET /auth/setup` is now documented in `openapi.yaml`
- [ ] Verify generated dashboard types cover the `checkNeedsSetup()` call

Closes AUG-31

🤖 Generated with [Claude Code](https://claude.com/claude-code)